### PR TITLE
Provisioned cocurn alias option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,14 @@ functions:
     provisionedConcurrency: 1
     concurrencyAutoscaling: true
 
-# full configuration
+  # full configuration
 
   world:
     handler: handler.world
     provisionedConcurrency: 1
     concurrencyAutoscaling:
       enabled: true
+      alias: provisioned
       maximum: 10
       minimum: 1
       usage: 0.75
@@ -61,6 +62,7 @@ You must provide atleast `provisionedConcurrency` and `concurrencyAutoscaling` t
 ### Defaults
 
 ```yaml
+alias: provisioned
 maximum: 10
 minimum: 1
 usage: 0.75

--- a/__tests__/aws/policy.test.ts
+++ b/__tests__/aws/policy.test.ts
@@ -9,7 +9,7 @@ const options: Options = {
 }
 
 describe('Policy', () => {
-  it('should construct comeplete policy object', () => {
+  it('should construct complete policy object', () => {
     const policy = new Policy(options, {
       function: 'foo',
       name: 'foo-svc-dev-foo',

--- a/__tests__/aws/target.test.ts
+++ b/__tests__/aws/target.test.ts
@@ -11,6 +11,7 @@ const TargetConstructor = () => {
 
   const data: AutoscalingConfig = {
     function: 'foo',
+    alias: 'provisioned',
     name: 'foo-svc-dev-foo',
     maximum: 10,
     minimum: 1,

--- a/__tests__/helpers/config.ts
+++ b/__tests__/helpers/config.ts
@@ -18,6 +18,7 @@ export const configDefault: AutoscalingConfig = {
   usage: 0.75,
   scaleInCooldown: 120,
   scaleOutCooldown: 0,
+  alias: 'provisioned',
 }
 
 export const configCustomMetricMin: AutoscalingConfig = {

--- a/__tests__/plugin.test.ts
+++ b/__tests__/plugin.test.ts
@@ -38,6 +38,25 @@ describe('Defaults', () => {
       configCustomMetricDefault,
     )
   })
+  it('should set custom provisioned alias', () => {
+    const alias = 'my-custom-alias'
+    const configMetric = {
+      ...configCustomMetricDefault,
+      alias,
+    }
+    const resource = configMetric.customMetric!.dimensions!.find(
+      (el) => el.name === 'Resource',
+    )!
+
+    resource.value = `${configMin.name}:${alias}`
+
+    expect(
+      plugin.defaults({
+        ...configCustomMetricMin,
+        alias,
+      }),
+    ).toEqual(configMetric)
+  })
 })
 
 describe('Resources', () => {

--- a/src/@types/types.d.ts
+++ b/src/@types/types.d.ts
@@ -23,6 +23,7 @@ export interface AwsFunctionConfig {
   scaleInCooldown?: number
   scaleOutCooldown?: number
   customMetric?: CustomMetricConfig
+  alias?: string
 }
 
 export interface CustomMetricConfig {

--- a/src/aws/target.ts
+++ b/src/aws/target.ts
@@ -28,7 +28,7 @@ export default class Target {
         Properties: {
           MaxCapacity: this.data.maximum,
           MinCapacity: this.data.minimum,
-          ResourceId: `function:${this.data.name}:provisioned`,
+          ResourceId: `function:${this.data.name}:${this.data.alias}`,
           ScalableDimension: 'lambda:function:ProvisionedConcurrency',
           ServiceNamespace: 'lambda',
           RoleARN: {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -70,6 +70,7 @@ export default class Plugin {
           customMetric: this.customMetricDefaults(
             config.customMetric,
             config.name,
+            config.alias,
           ),
         }
       : {}
@@ -82,6 +83,7 @@ export default class Plugin {
       usage: config.usage || 0.75,
       function: config.function,
       name: config.name,
+      alias: config.alias || 'provisioned',
       ...customMetricConfig,
     }
   }
@@ -89,6 +91,7 @@ export default class Plugin {
   customMetricDefaults(
     customMetric: CustomMetricConfig,
     functionName: string,
+    alias: AutoscalingConfig['alias'],
   ): CustomMetricConfig {
     const defaultDimensions: Dimension[] = [
       {
@@ -97,7 +100,7 @@ export default class Plugin {
       },
       {
         name: 'Resource',
-        value: `${functionName}:provisioned`,
+        value: `${functionName}:${alias}`,
       },
     ]
 


### PR DESCRIPTION
Our setup is a little unique where we overwrite the serverless default of "provisioned" for the provisioned cocurrency alias. This PR enables a different alias as an option.