### PR TITLE
Update schema to support strict validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-provisioned-concurrency-autoscaling",
-  "version": "1.2.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-provisioned-concurrency-autoscaling",
-  "version": "1.2.0",
+  "version": "1.3.1",
   "description": "Serverless Plugin for AWS Lambdas Provisioned Concurrency Auto Scaling configuration.",
   "main": "./lib/index.js",
   "files": [

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -26,7 +26,9 @@ const text = {
 
 const schema = {
   properties: {
-    concurrencyAutoscaling: { type: ['boolean', 'object'] },
+    concurrencyAutoscaling: {
+      anyOf: [{ type: 'boolean' }, { type: 'object' }],
+    },
   },
 }
 


### PR DESCRIPTION
- Update schema to support strict validation, required for sls v3
- Tests, linting, and building passes
- Tested with sls v2 and sls v3 and no errors given
- Closes #28