### PR TITLE
Allow cloudformation functions for enabled and provisionedConcurrency fields

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -139,12 +139,11 @@ export default class Plugin {
   validateFunctions(instance: ConcurrencyFunction): boolean {
     return !!(
       instance.provisionedConcurrency &&
-      instance.provisionedConcurrency > 0 &&
       instance.concurrencyAutoscaling &&
       ((typeof instance.concurrencyAutoscaling === 'boolean' &&
         instance.concurrencyAutoscaling) ||
         (typeof instance.concurrencyAutoscaling === 'object' &&
-          instance.concurrencyAutoscaling.enabled === true))
+          instance.concurrencyAutoscaling.enabled !== false))
     )
   }
 


### PR DESCRIPTION
I'm running into a scenario where I need to have Cloudformation functions to control a few settings, and I wasn't able to do so with the existing validateFunctions call.

If there's a specific structure needed for this, please let me know