### PR TITLE
Logging: switch to injected logger

### DIFF
--- a/__tests__/helpers/logging.ts
+++ b/__tests__/helpers/logging.ts
@@ -1,0 +1,39 @@
+import { Logging, Progress } from "serverless/classes/Plugin";
+
+function fakeLog(..._args: any[]) {
+    return;
+}
+
+const fakeProgress: Progress = {
+    namespace: "Testing",
+    name: "Test Progress",
+    update: function (_message: string): void {
+        throw new Error("Function not implemented.");
+    },
+    info: function (_message: string): void {
+        throw new Error("Function not implemented.");
+    },
+    notice: function (_message: string): void {
+        throw new Error("Function not implemented.");
+    },
+    remove: function (): void {
+        throw new Error("Function not implemented.");
+    }
+}
+
+export const mockLogging: Logging = {
+        log: {
+            error: fakeLog,
+            warning: fakeLog,
+            notice: fakeLog,
+            info: fakeLog,
+            debug: fakeLog,
+            verbose: fakeLog,
+            success: fakeLog,
+        },
+        writeText: (_text: string | string[]) => {},
+        progress: {
+            get: (_name: string) => fakeProgress,
+            create: (_args: { message?: string; name?: string }) => fakeProgress,
+        },
+    };

--- a/__tests__/plugin.test.ts
+++ b/__tests__/plugin.test.ts
@@ -11,6 +11,7 @@ import {
 } from './helpers/config'
 import { serverless } from './helpers/serverless'
 import { options } from './helpers/options'
+import { mockLogging } from './helpers/logging'
 import { expectedPolicy } from './helpers/policy'
 import {
   expectedTarget,
@@ -18,7 +19,7 @@ import {
 } from './helpers/target'
 import { ConcurrencyFunction } from 'src/@types'
 
-const plugin = new Plugin(serverless)
+const plugin = new Plugin(serverless, {}, mockLogging)
 
 describe('Validate', () => {
   it('should validate true', () => {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -12,7 +12,7 @@ import {
   CustomMetricConfig,
 } from './@types'
 import { schema } from './schema/schema';
-import { log } from '@serverless/utils/log';
+import { Logging } from 'serverless/classes/Plugin'
 
 const text = {
   CLI_DONE: 'Added Provisioned Concurrency Auto Scaling to CloudFormation!',
@@ -28,9 +28,13 @@ const text = {
 export default class Plugin {
   serverless: Serverless
   hooks: Record<string, unknown> = {}
+  options: unknown
+  logging: Logging
 
-  constructor(serverless: Serverless) {
+  constructor(serverless: Serverless, options, logging: Logging) {
     this.serverless = serverless
+    this.options = options
+    this.logging = logging
 
     if (
       this.serverless.configSchemaHandler &&
@@ -102,7 +106,7 @@ export default class Plugin {
       stage: this.serverless.getProvider('aws').getStage(),
     }
 
-    log.info(util.format(text.CLI_RESOURCE, config.function))
+    this.logging.log.info(util.format(text.CLI_RESOURCE, config.function))
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const resources: any[] = []
@@ -191,11 +195,11 @@ export default class Plugin {
     try {
       const pcFunctions = this.getFunctions()
       this.validate(pcFunctions)
-      log.info(util.format(text.CLI_START))
+      this.logging.log.info(util.format(text.CLI_START))
       this.process(pcFunctions)
-      log.info(util.format(text.CLI_DONE))
+      this.logging.log.info(util.format(text.CLI_DONE))
     } catch (err) {
-      log.info(util.format(text.CLI_SKIP, err.message))
+      this.logging.log.info(util.format(text.CLI_SKIP, err.message))
     }
   }
 }


### PR DESCRIPTION
Fixes #61

Stores a reference to the logging framework in the constructor and then uses it to log the current output